### PR TITLE
Allow specification of trello card url

### DIFF
--- a/blackbelt/commands/gh.py
+++ b/blackbelt/commands/gh.py
@@ -13,9 +13,9 @@ def cli():
 
 
 @cli.command()
-@click.argument('t_url')
-def pr(t_url):
-    pull_request(t_url)
+@click.option('--card', default='',nargs=1)
+def pr(card):
+    pull_request(card)
 
 
 @cli.command()

--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -64,7 +64,7 @@ def pull_request(t_url):
     if 'github.com' not in repo:
         raise ValueError("Current git origin not on github.com; aborting")
 
-    ticket = get_current_working_ticket()
+    ticket = get_current_working_ticket(t_url)
     md_link = "[%(name)s](%(url)s)" % ticket
 
     pr_description = """

--- a/blackbelt/handle_trello.py
+++ b/blackbelt/handle_trello.py
@@ -94,7 +94,7 @@ def get_current_working_ticket(t_url):
     else:
         url_cards = [card for card in my_cards if card['url'] == t_url]
 
-        if url_cards.count() > 0:
+        if len(url_cards) > 0:
             work_card = url_cards[0]
 
 


### PR DESCRIPTION
This simple PR allows to select a trello card by url during a pull request creation:

```
bb gh pr
```

Will select first card and will raise exception if more then one in Doing is found

```
bb gh pr --card https://trello.com/c/yqHPQhar/1111-my-supercard
```

Will select given card from Doing queue and will raise exception if the card is not found in the queue.
