### PR TITLE
[Trello] Use `git fetch` to fetch origin's state

### DIFF
--- a/blackbelt/handle_trello.py
+++ b/blackbelt/handle_trello.py
@@ -259,7 +259,7 @@ def next_card():
     if get_current_branch() != 'master':
         check_output(['git', 'checkout', 'master'])
 
-    check_output(['git', 'pull'])
+    check_output(['git', 'fetch', 'origin'])
 
     # You think you might do git checkout branch origin/branch?
     # Oh my, silly you. All of those require the origin branch to exists,


### PR DESCRIPTION
`git pull` has a side-effect of changing the current checkout, where as `git fetch` will fetch it and not affect the current checkout.