### PR TITLE
Deploy ref with branch instead of sha

### DIFF
--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -310,10 +310,7 @@ def deploy(pr_url):
         if click.prompt("Moving card failed. Open PR in browser?", default=True):
             webbrowser.open(merge_info['html_url'])
 
-    try:
-        create_release(ref=merge_info['branch'], payload='', description="Deployed to production")
-    except ValueError:
-        print 'Error during github release creation.'
+    create_release(ref=merge_info['branch'], payload='', description="Deployed to production")
 
 def create_release(ref, payload, description):
     """ Create release in github after deploy to production """

--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -305,10 +305,14 @@ def deploy(pr_url):
     try:
         ticket_id = get_pr_ticket_id(merge_info['description'])
         move_to_deployed(card_id=ticket_id, comment=comment)
-        create_release(ref=merge_info['sha'], payload='', description="Deployed to production")
     except ValueError:
         if click.prompt("Moving card failed. Open PR in browser?", default=True):
             webbrowser.open(merge_info['html_url'])
+
+    try:
+        create_release(ref=merge_info['sha'], payload='', description="Deployed to production")
+    except ValueError:
+        print 'Error during github release creation.'
 
 def create_release(ref, payload, description):
     """ Create release in github after deploy to production """

--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -244,7 +244,8 @@ def merge(pr_url):
         'number': pr_info['number'],
         'description': pr['body'],
         'html_url': pr['html_url'],
-        'title': pr['title']
+        'title': pr['title'],
+        'branch': pr['head']['ref']
     }
 
 
@@ -310,7 +311,7 @@ def deploy(pr_url):
             webbrowser.open(merge_info['html_url'])
 
     try:
-        create_release(ref=merge_info['sha'], payload='', description="Deployed to production")
+        create_release(ref=merge_info['branch'], payload='', description="Deployed to production")
     except ValueError:
         print 'Error during github release creation.'
 

--- a/blackbelt/tasks.py
+++ b/blackbelt/tasks.py
@@ -9,7 +9,7 @@ class BlackBelt(click.MultiCommand):
     def list_commands(self, ctx):
         rv = []
         for filename in os.listdir(plugin_folder):
-            if filename.endswith('.py') and filename is not '__init__.py':
+            if filename.endswith('.py') and filename != not '__init__.py':
                 rv.append(filename[:-3])
         rv.sort()
         return rv

--- a/blackbelt/tasks.py
+++ b/blackbelt/tasks.py
@@ -9,7 +9,7 @@ class BlackBelt(click.MultiCommand):
     def list_commands(self, ctx):
         rv = []
         for filename in os.listdir(plugin_folder):
-            if filename.endswith('.py'):
+            if filename.endswith('.py') and filename is not '__init__.py':
                 rv.append(filename[:-3])
         rv.sort()
         return rv


### PR DESCRIPTION
1. Avoid to list **__init__** as command
2. _create_release_ has got his own try/except block
3. Github deployment API uses now the merged branch as ref instead of sha (probably it is the cause that prevent the showing of branches)

I am definitely in trouble about how to test the stuff in python.