### PR TITLE
fix: explicit string conversion

### DIFF
--- a/blackbelt/deployment.py
+++ b/blackbelt/deployment.py
@@ -5,7 +5,7 @@ from blackbelt.messages import post_message
 
 
 def deploy_staging():
-    branch_name = get_current_branch()
+    branch_name = str(get_current_branch())
 
     post_message("Deploying branch %s to staging" % branch_name, "#deploy-queue")
 


### PR DESCRIPTION
```
Pushing to ‘git@heroku.com:apiary-compiler-staging.git’ (‘git push git@heroku.com:apiary-compiler-staging.git b'master':master --force’)...
```