### PR TITLE
Run grunt tasks in separate processes

### DIFF
--- a/blackbelt/deployment.py
+++ b/blackbelt/deployment.py
@@ -1,6 +1,6 @@
 from subprocess import check_call
 
-from blackbelt.handle_github import get_current_branch
+from blackbelt.handle_github import get_current_branch, run_grunt_in_parallel
 from blackbelt.messages import post_message
 
 
@@ -14,6 +14,11 @@ def deploy_staging():
 def deploy_production():
     post_message("Deploying to production", "#deploy-queue")
 
-    check_call(['grunt', 'deploy'])    
-    check_call(['grunt', 'deploy', '--app=apiary-staging-pre'])
-    check_call(['grunt', 'deploy', '--app=apiary-staging-qa'])
+    slug_creaction_rc = run_grunt_in_parallel((['grunt', 'create-slug'], ['grunt', 'create-slug', '--app=apiary-staging-pre'], ['grunt', 'create-slug', '--app=apiary-staging-qa']))
+    if slug_creaction_rc != 0:
+		post_message("Slug creation failed, deploy stopped.", "#deploy-queue")
+        raise ValueError("One of the slug creations failed. Check output few lines above.")
+
+    check_output(['grunt', 'deploy-slug', '--app=apiary-staging-qa'])
+    check_output(['grunt', 'deploy-slug', '--app=apiary-staging-pre'])
+    check_output(['grunt', 'deploy-slug'])

--- a/blackbelt/deployment.py
+++ b/blackbelt/deployment.py
@@ -14,9 +14,14 @@ def deploy_staging():
 def deploy_production():
     post_message("Deploying to production", "#deploy-queue")
 
-    slug_creaction_rc = run_grunt_in_parallel((['grunt', 'create-slug'], ['grunt', 'create-slug', '--app=apiary-staging-pre'], ['grunt', 'create-slug', '--app=apiary-staging-qa']))
-    if slug_creaction_rc != 0:
-		post_message("Slug creation failed, deploy stopped.", "#deploy-queue")
+    slug_creaction_return_code = run_grunt_in_parallel((
+        ['grunt', 'create-slug'],
+        ['grunt', 'create-slug', '--app=apiary-staging-pre'],
+        ['grunt', 'create-slug', '--app=apiary-staging-qa'],
+    ))
+
+    if slug_creaction_return_code != 0:
+        post_message("Slug creation failed, deploy stopped.", "#deploy-queue")
         raise ValueError("One of the slug creations failed. Check output few lines above.")
 
     check_output(['grunt', 'deploy-slug', '--app=apiary-staging-qa'])

--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -438,11 +438,11 @@ def run_grunt_in_parallel(grunt_commands):
                 next_round.append(command)
             else:
                 if rc == 0:
-                    print('Deploy to {} completed successfully.\n'.format(command['app']))
+                    print('Grunt task for {} completed successfully.\n'.format(command['app']))
                     os.remove(command['log'])
                 else:
                     return_code = rc
-                    print('Deploy to {} failed with exit code {}.'.format(command['app'], rc))
+                    print('Grunt task for {} failed with exit code {}.'.format(command['app'], rc))
                     print('Logfile can be found at {}\n'.format(command['log']))
 
         commands = next_round

--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -431,6 +431,7 @@ def run_grunt_in_parallel(grunt_commands):
     print('\n')
 
     while len(commands):
+        sleep(5)
         next_round = []
         for command in commands:
             rc = command['process'].poll()

--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -10,6 +10,7 @@ import requests
 
 import tempfile
 import os
+import re
 
 from .config import config
 from .handle_trello import (
@@ -423,7 +424,7 @@ def run_grunt_in_parallel(grunt_commands):
     commands = []
     for command in grunt_commands:
         with tempfile.NamedTemporaryFile(delete=False) as f:
-            app = command[2].split('=')[1] if len(command) > 2 else 'production'
+            app = get_grunt_application_name(' '.join(command))
             commands.append({'app': app, 'process': Popen(command, stdout=f), 'log': f.name})
             print('Running `{}` with PID {}'.format(' '.join(command), commands[-1]['process'].pid))
 
@@ -448,3 +449,9 @@ def run_grunt_in_parallel(grunt_commands):
 
 
     return return_code
+
+def get_grunt_application_name(command):
+    app_search = re.search("(--app=|-a=)(\w+)", command, re.IGNORECASE)
+    app = app_search.group(2) if app_search else "production"
+
+    return app

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -11,6 +11,7 @@ from blackbelt.handle_github import (
     verify_pr_required_checks,
     verify_branch_required_checks,
     run_grunt_in_parallel,
+    get_grunt_application_name,
 )
 
 
@@ -151,3 +152,8 @@ class TestParallelRunOfGruntTasks(object):
     def test_run_grunt_in_parallel_fail(self):
         commands = (['sleep', '1'], ['sleep', '1'], ['ls', '/dev/null/a'])
         assert_not_equal(0, run_grunt_in_parallel(commands))
+
+    def test_get_grun_application_name(self):
+        assert_equal('apiary', get_grunt_application_name('grunt create-slug --app=apiary'))
+        assert_equal('apiary', get_grunt_application_name('grunt create-slug -a=apiary'))
+        assert_equal('production', get_grunt_application_name('grunt create-slug'))

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises, assert_not_equal
 from mock import patch, MagicMock
 import requests
 import json
@@ -10,6 +10,7 @@ from blackbelt.handle_github import (
     verify_pr_state,
     verify_pr_required_checks,
     verify_branch_required_checks,
+    run_grunt_in_parallel,
 )
 
 
@@ -140,3 +141,13 @@ class TestGitHubPullRequestResponseData(object):
         assert_equal('Please pull these awesome changes', pr_details['body'])
         assert_equal('https://github.com/octocat/Hello-World/pull/1347', pr_details['html_url'])
         assert_equal('open', pr_details['state'])
+
+class TestParallelRunOfGruntTasks(object):
+
+    def test_run_grunt_in_parallel_success(self):
+        commands = (['sleep', '1'], ['sleep', '1'], ['sleep', '2'])
+        assert_equal(0, run_grunt_in_parallel(commands))
+
+    def test_run_grunt_in_parallel_fail(self):
+        commands = (['sleep', '1'], ['sleep', '1'], ['ls', '/dev/null/a'])
+        assert_not_equal(0, run_grunt_in_parallel(commands))


### PR DESCRIPTION
After setting up new environments (staging-qa, staging-pre), black-belt was modified to handle deploys to all of them. Unfortunately, it takes some time and is not so efficient. 

This PR present rough idea how to deal with it. Since I am not a skilled python dev, I'd like to hear your feedback.

My pain points:
- how to approach the tests? (I have no idea)
- should whole script fail if any of the grunt commands fails? (currently it doesn't, it tries to deploy all it could)

Thanks for a help to make black-belt usable again.