### PR TITLE
Handle incorrect argument, print output file locations

### DIFF
--- a/blackbelt/commands/dep.py
+++ b/blackbelt/commands/dep.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 import click
 
@@ -17,7 +18,10 @@ def validate_dep(ctx, param, dep):
         raise click.BadParameter('The dependency format should be e.g. react@16.2')
     else:
         if dep_version == 'latest':
-            dep_version = run(['npm', 'view', dep_name, 'version'])
+            try:
+                dep_version = run(['npm', 'view', dep_name, 'version'])
+            except subprocess.CalledProcessError:
+                raise click.BadParameter('The npm package does not exist')
         return (dep_name, dep_version)
 
 

--- a/blackbelt/commands/dep.py
+++ b/blackbelt/commands/dep.py
@@ -29,7 +29,7 @@ def validate_dep(ctx, param, dep):
                 else:
                     if ctx.params.get('debug'):
                         raise
-                    raise click.BadParameter('Unable to figure out the package version')
+                    raise click.Abort('Unable to figure out the package version')
         return (dep_name, dep_version)
 
 

--- a/blackbelt/dependencies.py
+++ b/blackbelt/dependencies.py
@@ -70,15 +70,18 @@ def check(dep, list_path, licenses_path, dev=False, debug=False):
     dep_name, dep_version = dep
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        install(dep_name, dep_version, tmp_dir, dev=dev)
+        try:
+            install(dep_name, dep_version, tmp_dir, dev=dev)
+        except subprocess.CalledProcessError:
+            raise click.BadParameter('The npm package could not be installed')
         licenses = license_checker(tmp_dir)
 
     pre_approval_verdict = get_pre_approval_verdict(licenses)
     details, fourth_party_licenses = separate_top_level_details(licenses, dep_name)
 
-    click.echo('Creating the list of 4th party deps...')
+    click.echo('Creating the list of 4th party deps... {}'.format(list_path.name))
     list_path.write(create_deps_list(fourth_party_licenses))
-    click.echo('Creating the Public License field contents...')
+    click.echo('Creating the Public License field contents... {}'.format(licenses_path.name))
     licenses_path.write(create_licenses_list(details, fourth_party_licenses))
 
     color = 'green' if pre_approval_verdict else 'red'

--- a/blackbelt/dependencies.py
+++ b/blackbelt/dependencies.py
@@ -72,7 +72,9 @@ def check(dep, list_path, licenses_path, dev=False, debug=False):
     with tempfile.TemporaryDirectory() as tmp_dir:
         try:
             install(dep_name, dep_version, tmp_dir, dev=dev)
-        except subprocess.CalledProcessError:
+        except Exception as e:
+            if debug:
+                raise
             raise click.BadParameter('The npm package could not be installed')
         licenses = license_checker(tmp_dir)
 


### PR DESCRIPTION
Introducing following changes:

- `bb dep check non-existing-package` doesn't crash anymore
- `bb dep check package@non-existing-version` doesn't crash anymore
- The `bb dep check` command prints out locations where the output files are saved

Before:

```sh
$ bb dep check chromedriver
Analyzing the package...
Getting dependencies...
Creating the list of 4th party deps...
Creating the Public License field contents...
```

After:

```sh
$ bb dep check chromedriver
Analyzing the package...
Getting dependencies...
Creating the list of 4th party deps... /Users/honza/Projects/black-belt/list.txt
Creating the Public License field contents... /Users/honza/Projects/black-belt/licenses.txt
```