### PR TITLE
Exit code & print more details

### DIFF
--- a/blackbelt/commands/dep.py
+++ b/blackbelt/commands/dep.py
@@ -1,5 +1,5 @@
 import os
-import subprocess
+import sys
 
 import click
 import requests
@@ -46,4 +46,5 @@ def validate_dep(ctx, param, dep):
               default=lambda: os.path.join(os.getcwd(), 'licenses.txt'),
               help='Where to save the Public License field contents.')
 def check(*args, **kwargs):
-    do_check(*args, **kwargs)
+    if not do_check(*args, **kwargs):
+        sys.exit(1)

--- a/blackbelt/dependencies.py
+++ b/blackbelt/dependencies.py
@@ -90,12 +90,18 @@ def check(dep, list_path, licenses_path, dev=False, debug=False):
     click.secho('\n{name}@{version}'.format(**details), bold=True, fg=color)
     click.echo((
         'License: {licenses}\n'
+        'Copyright Notice: {copyright_notice}\n'
         'Dependencies: {dependencies}\n'
-        'Elligible for Pre-Approval: {pre_approval_verdict}'
+        'Elligible for Pre-Approval: {pre_approval_verdict}\n\n'
+        'Package: https://npmjs.com/package/{name}\n'
+        'Repo: {repo}\n'
     ).format(
         licenses=details['licenses'],
+        copyright_notice=details['copyright_notice'],
         dependencies=len(fourth_party_licenses),
         pre_approval_verdict=pre_approval_verdict,
+        name=details['name'],
+        repo=details.get('repo', 'N/A'),
     ))
 
     problematic_licenses = [
@@ -130,6 +136,7 @@ def check(dep, list_path, licenses_path, dev=False, debug=False):
             )
         if not debug:
             click.echo('\nProTip: You can use --debug to print more details.')
+    return pre_approval_verdict
 
 
 def install(dep_name, dep_version, project_dir, dev=False):


### PR DESCRIPTION
Changes:

- `bb dep check` now returns exit code 1 if the library is not eligible for pre-approval. This allows further automation if one needs to verify multiple dependencies.
- Removed some unused imports.
- Printing more details about the top-level dependency. This simplifies adding the dependency to the 3rd party tracking, because you can just copy-paste these details from the output instead of looking them up on the npm/github.