### PR TITLE
fix: missing from check_output

### DIFF
--- a/blackbelt/deployment.py
+++ b/blackbelt/deployment.py
@@ -1,4 +1,4 @@
-from subprocess import check_call
+from subprocess import check_call, check_output
 
 from blackbelt.handle_github import get_current_branch, run_grunt_in_parallel
 from blackbelt.messages import post_message


### PR DESCRIPTION
```
`check_output(['grunt', 'deploy-slug', '--app=apiary-staging-qa'])
NameError: global name 'check_output' is not defined`
```