### PR TITLE
fix(dep): Don't use abort as this doesn't display error

### DIFF
--- a/blackbelt/commands/dep.py
+++ b/blackbelt/commands/dep.py
@@ -29,7 +29,7 @@ def validate_dep(ctx, param, dep):
                 else:
                     if ctx.params.get('debug'):
                         raise
-                    raise click.Abort('Unable to figure out the package version')
+                    raise click.ClickException('Unable to figure out the package version. See --debug for more information.')
         return (dep_name, dep_version)
 
 


### PR DESCRIPTION
Yesterday I started experiencing some problem with upstream NPM API and the resulting errors in black belt was confusing as Abort exception is used. Since Abort just prints abort to stderr and then exits it is unclear what the problem is. Here's the excerpt from click documentation on exception handling. See point 2 that Abort doesn't print the message, but ClickMessage does. I've also extending the message so that we tell the user they can get more info when they use `--debug`.

> The logic applied is the following:
> 
> 1) If an EOFError or KeyboardInterrupt happens, reraise it as Abort.
If an ClickException is raised, invoke the ClickException.show() method on it to display it and then exit the program with ClickException.exit_code.
> 1) If an Abort exception is raised print the string Aborted! to standard error and exit the program with exit code 1.
> 1) if it goes through well, exit the program with exit code 0.

#### Before

```shell
$ bb dep check Commander
Aborted!
```

#### After

```shell
$ bb dep check Commander
Error: Unable to figure out the package version. See --debug for more information.
```

For those wondering what debug looks like:

```
$ bb dep check Commander --debug
...

  File "/Users/kyle/Projects/apiaryio/black-belt/blackbelt/commands/dep.py", line 24, in validate_dep
    response.raise_for_status()
  File "/Users/kyle/Projects/apiaryio/black-belt/venv/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 522 Server Error: Origin Connection Time-out for url: https://api.npms.io/v2/package/Commander
```