### PR TITLE
Use sha instead of branch

### DIFF
--- a/blackbelt/handle_github.py
+++ b/blackbelt/handle_github.py
@@ -397,7 +397,7 @@ def deploy(pr_url):
         if click.confirm("Moving card failed. Open PR in browser?", default=True):
             webbrowser.open(merge_info['html_url'])
 
-    create_release(ref=merge_info['branch'], payload='', description="Deployed to production", repo_info=repo_info)
+    create_release(ref=merge_info['sha'], payload='', description="Deployed to production", repo_info=repo_info)
 
 def create_release(ref, payload, description, repo_info):
     """ Create release in github after deploy to production """


### PR DESCRIPTION
My attempt to solve https://github.com/apiaryio/black-belt/issues/111. Not tested, this is pure shooting into dark. My idea is we cannot create the deployment using the branch as a ref, because we delete the branch after merging. Instead, we could probably use the sha. Let's see. It's already broken, so this change cannot make it more broken. Hopefully.

The GitHub error is:

```python
{
    'message': 'No ref found for: honzajavorek/clean-up-client',
    'documentation_url': 'https://developer.github.com/v3/repos/deployments/#create-a-deployment'
}
```